### PR TITLE
Add .Net 6.0 support and fix issue with PropertyName for the whole entity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,10 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 5.0.x
+    - name: Setup .NET 6.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,10 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 5.0.x
+    - name: Setup .NET 6.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
     - name: Pack
       run: |
         cd src

--- a/src/FluentValidation.HttpExtensions.csproj
+++ b/src/FluentValidation.HttpExtensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <LangVersion>9</LangVersion>
         <AssemblyName>Pankraty.FluentValidation.HttpExtensions</AssemblyName>
         <Title>Pankraty.FluentValidation.HttpExtensions</Title>

--- a/src/IRuleBuilderExtensions.cs
+++ b/src/IRuleBuilderExtensions.cs
@@ -34,16 +34,23 @@ namespace FluentValidation.HttpExtensions
             ruleBuilder.UseHttpCode(HttpStatusCode.Locked);
 
         private static string BuildPropertyName(HttpStatusCode httpStatusCode) =>
-            $"{ErrorStatusConst.Prefix}{(int) httpStatusCode}";
+            $"{ErrorStatusConst.Prefix}{(int)httpStatusCode}";
 
         private static IRuleBuilderOptions<T, TProperty> UseHttpCode<T, TProperty>(
             this IRuleBuilderOptions<T, TProperty> ruleBuilder, HttpStatusCode httpStatusCode)
         {
             string propertyName = "";
-            return ruleBuilder
-                .Configure(x => propertyName = x.GetDisplayName(null))
-                .WithName(propertyName)
-                .OverridePropertyName(BuildPropertyName(httpStatusCode));
+
+            var options = ruleBuilder.Configure(x => propertyName = x.GetDisplayName(null));
+
+            if (!string.IsNullOrEmpty(propertyName))
+            {
+                options.WithName(propertyName);
+            }
+
+            options.OverridePropertyName(BuildPropertyName(httpStatusCode));
+
+            return options;
         }
     }
 }

--- a/tests/FluentValidation.HttpExtensions.Unit/FluentValidation.HttpExtensions.Unit.csproj
+++ b/tests/FluentValidation.HttpExtensions.Unit/FluentValidation.HttpExtensions.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <LangVersion>9</LangVersion>
     </PropertyGroup>
 

--- a/tests/FluentValidation.HttpExtensions.Unit/NotFoundControllerShould.cs
+++ b/tests/FluentValidation.HttpExtensions.Unit/NotFoundControllerShould.cs
@@ -36,14 +36,16 @@ namespace FluentValidation.HttpExtensions.Unit
                 {
                     "Could not find Name James Bond",
                     "Could not find Address London, Great Britain",
+                    "Could not find entity"
                 });
         }
 
         [Fact]
         public async Task Use_Single_Message_When_Another_Rule_Passed()
         {
-            _testEntity.Name = "Existing";
-            _testEntity.Address = "London, Great Britain";
+            _testEntity.Name = "James Bond";
+            _testEntity.PostalCode = "Existing";
+            _testEntity.Address = "Existing";
 
             var response = await Post();
             var problems = await response.DeserializeAs<ValidationProblemDetails>();
@@ -51,7 +53,7 @@ namespace FluentValidation.HttpExtensions.Unit
             response.StatusCode.Should().Be(HttpStatusCode.NotFound);
             problems.Errors.Should()
                 .OnlyContain(x => x.Key == "" &&
-                                  x.Value.Single() == "Could not find Address London, Great Britain");
+                                  x.Value.Single() == "Could not find Name James Bond");
         }
 
         [Fact]
@@ -59,6 +61,7 @@ namespace FluentValidation.HttpExtensions.Unit
         {
             _testEntity.Name = "Existing";
             _testEntity.Address = "Existing";
+            _testEntity.PostalCode = "Existing";
 
             var response = await Post();
 

--- a/tests/TestApplication/TestApplication.csproj
+++ b/tests/TestApplication/TestApplication.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <LangVersion>9</LangVersion>
     </PropertyGroup>
 

--- a/tests/TestInfrastructure/NotFoundValidator.cs
+++ b/tests/TestInfrastructure/NotFoundValidator.cs
@@ -16,6 +16,11 @@ namespace FluentValidation.HttpExtensions.TestInfrastructure
                 .Must(x => x == "Existing")
                 .AsNotFound()
                 .WithMessage("Could not find {PropertyName} {PropertyValue}");
+
+            RuleFor(x => x)
+                .Must(x => x.Address == "Existing" && x.PostalCode == "Existing")
+                .AsNotFound()
+                .WithMessage("Could not find entity");
         }
     }
 }

--- a/tests/TestInfrastructure/TestEntity.cs
+++ b/tests/TestInfrastructure/TestEntity.cs
@@ -16,5 +16,6 @@ namespace FluentValidation.HttpExtensions.TestInfrastructure
     {
         public string Name { get; set; }
         public string Address { get; set; }
+        public string PostalCode { get; set; }
     }
 }

--- a/tests/TestInfrastructure/TestInfrastructure.csproj
+++ b/tests/TestInfrastructure/TestInfrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <LangVersion>9</LangVersion>
         <RootNamespace>FluentValidation.HttpExtensions.TestInfrastructure</RootNamespace>
     </PropertyGroup>


### PR DESCRIPTION
In my current project I'd like to use the package but faced with an issue. I have tried to use `AsNotFound` for the whole entity, but not the certain property. Here is an example:
```
RuleFor(x => x)
.Must(x => x.Id != null & x.Name != null && x.Email)
.AsNotFound();
```
It fails with the error
> System.ArgumentNullException: 'A property name must be specified when calling WithName. Arg_ParamName_Name'

As a fix for it, I suggest using `.WithName()` method only if PropertyName is defined. Otherwise, we don't know what should be used as the property name.

I also added .Net 6.0 to the list of supported versions.